### PR TITLE
Add a user visible notification when long-press was blocked by magic_mapper.

### DIFF
--- a/magic_mapper.py
+++ b/magic_mapper.py
@@ -563,6 +563,8 @@ def input_loop(button_map):
                 print("WARNING: Got code %s UP with no DOWN" % code)
             elif now - buttons_waiting[code] > 1.0:
                 print("Ignoring long press of %s" % key)
+                # Tell the user that the long press was blocked because of magic mapper; to avoid any confusion.
+                luna_send("luna://com.webos.notification/createToast", {"sourceId":"magic mapper","message":"long press for %s is disabled due to magic mapper" % key})
             else:
                 print("%s button up" % key)
                 print("firing event(s) for code: %s button: %s" % (code, key))


### PR DESCRIPTION
I totally forgot about the created mapping and I was wondering why long press for 1/2/3 keys was not launching the quick access apps (HDMI 1/2/3 resp.)
This user-visible notification helps clear that confusion.