### PR TITLE
Discover output device path by name. Add option to toggle piccap service

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The script has support to do the the following (default config button):
 - [Send hdmi-cec key presses](#send_cec_button) (EXPERIMENTAL)
 - [Disable the Magic Remote mouse](#disable-mouse-experimental) (EXPERIMENTAL)
 - [Send a TCP command](#send_tcp_command) (not configured by default)
+- [Toggle PicCap](#toggle_piccap) (not configured by default)
 
 ## TV Models supported (Likely any LG TV after 2018 are supported until this stops working with unknown future models)
 
@@ -417,6 +418,18 @@ To disable the mouse, edit the script and change `BLOCK_MOUSE = True` near the t
       "timeout": 10
     }
   }
+  ```
+
+### toggle_piccap
+
+- Toggles the WebOSBrew PicCap service on or off. This requires PicCap to be installed.
+- Inputs: None
+- Example:
+  ```
+  "blue": {
+    "function": "toggle_piccap"
+  }
+  ```
 
 ## Button List
 

--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ Note that long presses (longer than 1s) are ignored. I will eventually add suppo
  "netflix"
  "disney"
  "lg_channels"
+ "rakuten"
  "alexa"
  "google"
  "guide"

--- a/magic_mapper.py
+++ b/magic_mapper.py
@@ -52,6 +52,7 @@ BUTTONS = {
     1037: "netflix",
     1042: "disney",
     1043: "lg_channels",
+    1044: "rakuten",
     1086: "alexa",
     1117: "google",
     362: "guide",

--- a/magic_mapper.py
+++ b/magic_mapper.py
@@ -336,6 +336,10 @@ def send_tcp_command(inputs):
     except Exception as e:
         print("ERROR: An unexpected error occurred in send_tcp_command: %s" % e)
 
+def toggle_piccap(inputs):
+    command = 'if /usr/bin/luna-send -n 1 \'luna://org.webosbrew.piccap.service/status\' \'{}\' | grep \'"isRunning":true\'; then /usr/bin/luna-send -n 1 \'luna://org.webosbrew.piccap.service/stop\' \'{}\' ; else /usr/bin/luna-send -n 1 \'luna://org.webosbrew.piccap.service/start\' \'{}\' ; fi'
+    os.popen(command)
+
 ###################################
 # Private Functions
 # The fuctions below here should not be called by magic_mapper_config.json

--- a/magic_mapper.py
+++ b/magic_mapper.py
@@ -339,8 +339,19 @@ def send_tcp_command(inputs):
         print("ERROR: An unexpected error occurred in send_tcp_command: %s" % e)
 
 def toggle_piccap(inputs):
-    command = 'if /usr/bin/luna-send -n 1 \'luna://org.webosbrew.piccap.service/status\' \'{}\' | grep \'"isRunning":true\'; then /usr/bin/luna-send -n 1 \'luna://org.webosbrew.piccap.service/stop\' \'{}\' ; else /usr/bin/luna-send -n 1 \'luna://org.webosbrew.piccap.service/start\' \'{}\' ; fi'
-    os.popen(command)
+    piccap_service = "luna://org.webosbrew.piccap.service"
+    status = luna_send("%s/status" % piccap_service, {})
+    status = json.loads(status)
+
+    if status.get("isRunning"):
+        action = "stopped"
+        endpoint = "%s/stop" % piccap_service
+    else:
+        action = "started"
+        endpoint = "%s/start" % piccap_service
+
+    luna_send(endpoint, {})
+    print("PicCap service %s" % action)
 
 ###################################
 # Private Functions

--- a/magic_mapper.py
+++ b/magic_mapper.py
@@ -20,7 +20,7 @@ DEVICE_NAME = 'LGE M-RCU - Builtin [0]'   # the exact Name= shown in /proc/bus/i
 # DEVICE_NAME = 'LGE M-RCU - Builtin [1]'   # UNTESTED - Try this for IR remotes
 
 
-OUTPUT_DEVICE = "/dev/input/event4"  # unbound codes get resent to this device in exclusive mode
+OUTPUT_DEVICE_NAME = 'LGE M-RCU - Builtin [2]'  # unbound codes get resent to this device in exclusive mode
 
 
 BUTTONS = {
@@ -247,8 +247,9 @@ def press_button(inputs):
     keycode = get_keycode(button)
     if not keycode:
         return
-    print("Simulating keystroke with button '%s' (keycode %s)" % (button, keycode))
-    send_keystroke(OUTPUT_DEVICE, keycode)
+    output_device_path = resolve_input_device_by_name(OUTPUT_DEVICE_NAME)
+    print("Simulating keystroke with button '%s' (keycode %s). Output device: %s" % (button, keycode, output_device_path))
+    send_keystroke(output_device_path, keycode)
 
 
 def send_cec_button(inputs):
@@ -493,7 +494,9 @@ def input_loop(button_map):
     if EXCLUSIVE_MODE:
         print("EXCLUSIVE_MODE is enabled, taking over input device")
         fcntl.ioctl(input_device, EVIOCGRAB, 1)
-        output_device = os.open(OUTPUT_DEVICE, os.O_WRONLY)
+        output_device_path = resolve_input_device_by_name(OUTPUT_DEVICE_NAME)
+        print("Keys will be resent to: %s" % output_device_path)
+        output_device = os.open(output_device_path, os.O_WRONLY)
     else:
         print("EXCLUSIVE_MODE is disabled, will not override default button behavior")
         output_device = None


### PR DESCRIPTION
Output device should not be hardcoded. Same as input device, it changes between reboots.

I also added ability to toggle piccap to turn on/off ambient light. I can remove it from this PR if you don't want it.

Tested on LG C4 webOS 25