### PR TITLE
Fix luna_send silent no-op on webOS 10.x

### DIFF
--- a/magic_mapper.py
+++ b/magic_mapper.py
@@ -391,6 +391,25 @@ def fire_events(actions):
 
 def luna_send(endpoint, payload):
     # Execute luna send and return the output
+    #
+    # webOS 10.x (Rockhopper) regression: `luna-send -n 1` is a silent no-op --
+    # it neither prints a response nor actually delivers the message, so every
+    # bound button would appear to do nothing. Verified A/B on an OLED65C4PUA
+    # (webOS 10.3.1): an identical launch call fires with `-t 1` and does nothing
+    # with `-n 1`. `-t 1` delivers exactly once (it means "time 1 iteration"),
+    # but the response payload comes back on STDERR behind a
+    # "timingServiceResponse" line, so the callers that json.loads() this need it
+    # recovered from there.
+    #
+    # Gated on version so pre-10 devices keep the exact original code path.
+    if WEBOS_MAJOR_VERSION >= 10:
+        command = ["/usr/bin/luna-send", "-t", "1", endpoint, json.dumps(payload)]
+        print("running command: %s" % command)
+        proc = subprocess.run(command, capture_output=True)
+        for line in proc.stderr.decode("utf-8", "replace").splitlines():
+            if "timingServiceResponse" in line and "{" in line:
+                return line[line.find("{"):]
+        return proc.stdout.decode("utf-8", "replace")
 
     command = ["/usr/bin/luna-send", "-n", "1"]
     command.append(endpoint)


### PR DESCRIPTION
On **webOS 10.x** (Rockhopper), `luna-send -n 1` is a silent no-op: it neither prints a response **nor delivers the message**. Since every mapped action ultimately calls `luna_send()`, buttons appear to do nothing — the script starts, grabs the remote, logs button presses, but no launch/command ever fires.

### Evidence

A/B on an LG OLED65C4PUA (`webos_release` 10.3.1, Rockhopper 10.3.1-3006), same URI/payload, only the flag differs:

| flag | foreground app after a browser-launch call |
|------|--------------------------------------------|
| `-n 1` | unchanged — **not delivered** |
| `-t 1` | `com.webos.app.browser` — delivered |

`-t 1` (`--time`, "average over 1 iteration") delivers exactly once. The one wrinkle: the response payload comes back on **stderr**, behind a `timingServiceResponse` line, so the callers that `json.loads()` the return value (`get_picture_settings`, the foreground-app check, `toggle_piccap`) need it recovered from there.

### The fix

Gated on `WEBOS_MAJOR_VERSION >= 10`, so **pre-10 devices keep the exact original `-n 1` code path, byte for byte** — no behavior change for existing C9/CX/C1/C2 users. The script already reads `WEBOS_MAJOR_VERSION` at startup and branches on it elsewhere (`if WEBOS_MAJOR_VERSION < 5`), so this reuses an established pattern.

```python
if WEBOS_MAJOR_VERSION >= 10:
    command = ["/usr/bin/luna-send", "-t", "1", endpoint, json.dumps(payload)]
    proc = subprocess.run(command, capture_output=True)
    for line in proc.stderr.decode("utf-8", "replace").splitlines():
        if "timingServiceResponse" in line and "{" in line:
            return line[line.find("{"):]
    return proc.stdout.decode("utf-8", "replace")
# ...original -n 1 path unchanged below
```

Tested on the C4 above: with this change all five of my mapped buttons fire (app launches + a browser deep-link); reverting to `-n 1` breaks all of them.

### Two notes

- **I could only test on webOS 10.3.1.** The `>= 10` cutoff is where I *observed* the regression; if it actually began somewhere in webOS 9.x, the threshold should drop. You have the hardware range to pin that — happy to adjust.
- `list_apps.py` has the same `-n 1` call and is affected too. I left it out to keep this diff to the runtime path; glad to include a fix if you would like it in the same PR.

Thanks for magic_mapper — it is exactly the right tool for this.