### PR TITLE
Add missing buttons from LG C5 remote

### DIFF
--- a/magic_mapper.py
+++ b/magic_mapper.py
@@ -69,7 +69,15 @@ BUTTONS = {
     1116: "tv",
     358: "info",
     773: "home",
-    28: "ok"
+    28: "ok",
+    412: "back",
+    1123: "home_hub",
+    1124: "accessibility",
+    139: "settings",
+    103: "up",
+    108: "down",
+    105: "left",
+    106: "right",
 }
 
 MOUSE_WHEEL = {


### PR DESCRIPTION
Added some keycodes that were missing from the remote that came with my LG C5.